### PR TITLE
fix: import useRef in App component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { supabase } from './supabaseClient'
 import { useTranslation } from 'react-i18next'
 import DatePicker from './DatePicker'


### PR DESCRIPTION
## Summary
- fix ReferenceError by importing `useRef` from React in `App.jsx`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b0bbf01918832b998ee626d2f376e0