### PR TITLE
Register service worker for PWA

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,9 @@ import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 import './i18n'
+import { registerSW } from 'virtual:pwa-register'
+
+registerSW()
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- register service worker on app startup so PWA features work in production

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b0c9c06538832b919ec752fe7d9fc4