### PR TITLE
feat: improve offline caching

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,14 @@ function uid() {
 }
 
 export default function App() {
-  const [tasks, setTasks] = useState([])
+  const [tasks, setTasks] = useState(() => {
+    try {
+      const stored = localStorage.getItem('tasks')
+      return stored ? JSON.parse(stored) : []
+    } catch {
+      return []
+    }
+  })
   const [text, setText] = useState('')
   const [description, setDescription] = useState('')
   const [tagInput, setTagInput] = useState('')
@@ -59,10 +66,16 @@ export default function App() {
         .from('tasks')
         .select('*')
         .order('created_at', { ascending: false })
-      setTasks(data ?? [])
+      if (data) {
+        setTasks(data)
+      }
     }
     load()
   }, [])
+
+  useEffect(() => {
+    localStorage.setItem('tasks', JSON.stringify(tasks))
+  }, [tasks])
 
   const allTags = useMemo(() => {
     const set = new Set()

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,46 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        runtimeCaching: [
+          {
+            urlPattern: ({ request }) => request.destination === 'document',
+            handler: 'NetworkFirst',
+            options: { cacheName: 'html-cache' }
+          },
+          {
+            urlPattern: ({ request }) =>
+              request.destination === 'script' || request.destination === 'style',
+            handler: 'StaleWhileRevalidate',
+            options: { cacheName: 'static-resources' }
+          },
+          {
+            urlPattern: ({ request }) => request.destination === 'image',
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'image-cache',
+              expiration: {
+                maxEntries: 60,
+                maxAgeSeconds: 60 * 60 * 24 * 30
+              }
+            }
+          },
+          {
+            urlPattern: ({ url }) => url.origin.includes('supabase.co'),
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'supabase-cache',
+              networkTimeoutSeconds: 10,
+              cacheableResponse: { statuses: [0, 200] },
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 60 * 60
+              }
+            }
+          }
+        ]
+      },
       manifest: {
         name: 'TaskKeeper',
         short_name: 'TaskKeeper',


### PR DESCRIPTION
## Summary
- cache PWA assets with tailored workbox runtime strategies
- persist tasks to localStorage so they load even offline

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f8a90f68832bbdf511fe4d068fe4