### PR TITLE
Handle offline task updates without sync errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -148,7 +148,13 @@ export default function App() {
 
   function syncTask(task, attempt = task.attempts || 0) {
     if (!navigator.onLine) return
-    const { action, ...dbTask } = task
+    const {
+      action,
+      pending: _pending,
+      attempts: _attempts,
+      error: _error,
+      ...dbTask
+    } = task
     let request
     if (action === 'insert') {
       request = supabase.from('tasks').insert([dbTask]).select().single()


### PR DESCRIPTION
## Summary
- Skip Supabase writes when offline and retry once connection returns
- Catch failed sync attempts so tasks stay editable while offline
- Strip client-only flags before syncing tasks to Supabase

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b208e80cc0832b853e27dbdbb10f88