### PR TITLE
fix: prevent sync failure when updating tasks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -159,7 +159,7 @@ export default function App() {
     if (action === 'insert') {
       request = supabase.from('tasks').insert([dbTask]).select().single()
     } else if (action === 'update') {
-      const { id, ...fields } = dbTask
+      const { id, created_at, ...fields } = dbTask
       request = supabase
         .from('tasks')
         .update(fields)


### PR DESCRIPTION
## Summary
- avoid sending `created_at` when updating tasks so sync completes

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b2110ec890832b802838a112b48c89