### PR TITLE
fix: prevent sync failure when updating tasks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -159,7 +159,7 @@ export default function App() {
     if (action === 'insert') {
       request = supabase.from('tasks').insert([dbTask]).select().single()
     } else if (action === 'update') {
-      const { id, ...fields } = dbTask
+      const { id, created_at, ...fields } = dbTask
       request = supabase
         .from('tasks')
         .update(fields)
@@ -233,23 +233,18 @@ export default function App() {
   }
 
   function toggleDone(id) {
-    let updated
-    setTasks(prev => {
-      const task = prev.find(t => t.id === id)
-      if (!task) return prev
-      updated = {
-        ...task,
-        done: !task.done,
-        pending: true,
-        action: task.pending ? task.action : 'update',
-        attempts: task.pending ? task.attempts : 0,
-        error: false,
-      }
-      return prev.map(t => (t.id === id ? updated : t))
-    })
-    if (updated) {
-      syncTask(updated)
+    const task = tasks.find(t => t.id === id)
+    if (!task) return
+    const updated = {
+      ...task,
+      done: !task.done,
+      pending: true,
+      action: task.pending ? task.action : 'update',
+      attempts: task.pending ? task.attempts : 0,
+      error: false,
     }
+    setTasks(prev => prev.map(t => (t.id === id ? updated : t)))
+    syncTask(updated)
   }
 
   async function clearCompleted() {


### PR DESCRIPTION
## Summary
- avoid sending `created_at` when updating tasks so sync completes
- ensure `toggleDone` triggers `syncTask` to send status updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2110ec890832b802838a112b48c89