### PR TITLE
fix: compute today using local time

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -120,7 +120,7 @@ export default function App() {
   useEffect(() => {
     if (typeof window === 'undefined' || !('Notification' in window)) return
 
-    const today = new Date().toISOString().split('T')[0]
+    const today = new Date().toLocaleDateString('en-CA')
 
     if (Notification.permission === 'default') {
       Notification.requestPermission()


### PR DESCRIPTION
## Summary
- compute today's date using the local timezone for due-today notifications

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b326289160832bb236b968c16f688b